### PR TITLE
Add a keep-alive NOOP to the C-Gate connection

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ var event = new net.Socket();
 var HOST = settings.cbusip;
 var COMPORT = 20023;
 var EVENTPORT = 20025;
+var KEEPALIVE = 30;
 
 var logging = settings.logging;
 
@@ -64,6 +65,11 @@ function started(){
         command.write('GET //'+settings.cbusname+'/'+settings.getallnetapp+'/* level\n');
       },settings.getallperiod*1000);
     }
+    // Send a NOOP to the Cgate server to keep the connection open and detect if the connection was closed
+    setInterval(function(){
+      console.log('NOOP');
+      command.write('NOOP\n');
+    },KEEPALIVE);
   }
 
 }


### PR DESCRIPTION
At times, the C-Gate connection may be interrupted due to connectivity issues (i.e. WiFi dropouts) or because the server crashed or was restarted. We won't find out about this until we attempt to write to the socket possibly hours after the connection was dropped.

Add a periodic NOOP command on the C-Gate connection to detect a failed connection sooner.